### PR TITLE
Use twine for publishing to pypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-0.2.0 (pshirali)
---------------
+0.2.0 (pshirali, ksindi)
+------------------------
 
+1. #18: Use twine for uploading to pypi.
 1. #16: Detect and verify async methods, generators and their combination
 1. #15: Project cleanup: flake8, deepsource, makefile and setup.py
 1. #11: Detect and verify staticmethods, classmethods

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ docs:
 
 .PHONY: release
 release: clean build
-	python3 setup.py sdist upload
-	python3 setup.py bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 
 .PHONY: dist
 dist: clean build

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ docs:
 
 .PHONY: release
 release: clean build
-	python setup.py sdist bdist_wheel
+	python3 setup.py sdist bdist_wheel
 	twine upload dist/*
 
 .PHONY: dist


### PR DESCRIPTION
[Twine](https://pypi.org/project/twine/) is the preferred method for publishing packages to pypi.