### PR TITLE
Implements version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
+0.3.0 (pshirali, KyleKing)
+------------------------
+
+1. #25: Fix: Extra data-descriptors from the implementation won't raise errors (pshirali)
+1. #24: Implementations are prevented from inheriting from interfaces (pshirali)
+1. #22: Method signatures of data-descriptors are additionally verified (pshirali)
+1. #21: Interface errors are collected and reported together (KyleKing)
+
+
 0.2.0 (pshirali, ksindi)
 ------------------------
 
-1. #18: Use twine for uploading to pypi.
-1. #16: Detect and verify async methods, generators and their combination
-1. #15: Project cleanup: flake8, deepsource, makefile and setup.py
-1. #11: Detect and verify staticmethods, classmethods
-1. #10: Fix: Verification when implementation has a property decorator
+1. #18: Use twine for uploading to pypi. (ksindi)
+1. #16: Detect and verify async methods, generators and their combination (pshirali)
+1. #15: Project cleanup: flake8, deepsource, makefile and setup.py (pshirali)
+1. #11: Detect and verify staticmethods, classmethods (pshirali)
+1. #10: Fix: Verification when implementation has a property decorator (pshirali)
 1. #8,#9: Moved license from MIT to Apache 2.0 (ksindi, pshirali)
-1. #5: Added additional tests for existing scenarios. Improved others.
+1. #5: Added additional tests for existing scenarios. Improved others. (pshirali)

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,9 @@ Advantages
 Usage
 -----
 
+With _implements_, implementation classes and interface classes must have their own independent class hierarchies. Unlike common patterns, the implementation class must not inherit from an interface class. From version ``0.3.0`` and onwards, this condition is checked automatically and an error is raised on a violation.
+
+
 .. code-block:: python
 
     from implements import Interface, implements

--- a/implements.py
+++ b/implements.py
@@ -154,9 +154,9 @@ def verify_properties(interface_cls, cls):
         cls_prop = getattr(cls, name, None)
         for attr in prop_attrs:
             # instanceof doesn't work for class function comparison
-            ifc_prop_type = type(getattr(prop, attr, None))
-            cls_prop_type = type(getattr(cls_prop, attr, None))
-            if ifc_prop_type != cls_prop_type:
+            ifc_prop_obj = getattr(prop, attr, None)
+            cls_prop_obj = getattr(cls_prop, attr, None)
+            if ifc_prop_obj and type(ifc_prop_obj) != type(cls_prop_obj):
                 cls_name = cls.__name__
                 ifc_name = interface_cls.__name__
                 proptype = prop_attrs[attr]

--- a/implements.py
+++ b/implements.py
@@ -44,6 +44,7 @@ def implements(interface_cls):
     defined by the `interface_cls`.
     """
     def _decorator(cls):
+        verify_class_hierarchy(interface_cls, cls)
         errors = []
         errors.extend(verify_methods(interface_cls, cls))
         errors.extend(verify_properties(interface_cls, cls))
@@ -55,6 +56,26 @@ def implements(interface_cls):
         return cls
 
     return _decorator
+
+
+
+def get_mro(cls):
+    return cls.mro()[:-1] if cls.mro()[-1] is object else cls.mro()
+
+
+def verify_class_hierarchy(ifc, cls):
+    ifc_mro = get_mro(ifc)
+    cls_mro = get_mro(cls)
+    common = set(ifc_mro) & set(cls_mro)
+    if len(common):
+        raise ValueError(
+            "Found {} common classes between the implementation and the "
+            "interface. Expected none. The implementation class and any "
+            "class in its class-hierarchy, must not inherit from the "
+            "interface class, or any class from the interface hierarchy. "
+            "Common classes: [{}]"
+            "".format(len(common), ", ".join([str(s) for s in common]))
+        )
 
 
 def getobj_via_dict(cls, name):

--- a/implements.py
+++ b/implements.py
@@ -58,7 +58,6 @@ def implements(interface_cls):
     return _decorator
 
 
-
 def get_mro(cls):
     return cls.mro()[:-1] if cls.mro()[-1] is object else cls.mro()
 

--- a/implements.py
+++ b/implements.py
@@ -156,14 +156,31 @@ def verify_properties(interface_cls, cls):
             # instanceof doesn't work for class function comparison
             ifc_prop_obj = getattr(prop, attr, None)
             cls_prop_obj = getattr(cls_prop, attr, None)
-            if ifc_prop_obj and type(ifc_prop_obj) != type(cls_prop_obj):
+            if ifc_prop_obj:
                 cls_name = cls.__name__
                 ifc_name = interface_cls.__name__
                 proptype = prop_attrs[attr]
-                errors.append(
-                    "'{}' must implement a {} for property '{}' defined in "
-                    "interface '{}'".format(cls_name, proptype, name, ifc_name)
-                )
+
+                # -- verify presence and type of data-descriptors
+                if type(ifc_prop_obj) != type(cls_prop_obj):
+                    errors.append(
+                        "'{}' must implement a {} for property '{}' defined "
+                        "in interface '{}'"
+                        "".format(cls_name, proptype, name, ifc_name)
+                    )
+                    continue
+
+                # -- verify signatures of data-descriptors
+                ifc_prop_sig = inspect.signature(ifc_prop_obj)
+                cls_prop_sig = None
+                if callable(cls_prop_obj):
+                    cls_prop_sig = inspect.signature(cls_prop_obj)
+                if ifc_prop_sig != cls_prop_sig:
+                    errors.append(
+                        "'{}' must implement a {} for property '{}' with the "
+                        "same signature as defined in interface '{}'"
+                        "".format(cls_name, proptype, name, ifc_name)
+                    )
     return errors
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ with open('README.rst') as f:
 
 _DESCRIPTION = 'Pythonic interfaces using decorators'
 
-_AUTHORS = ('Kamil Sindi <ksindi@ksindi.com>, '
-            'Praveen G shirali <praveengshirali@gmail.com')
+_AUTHORS = 'Kamil Sindi <ksindi@ksindi.com>'
 
 _INSTALL_REQUIRES = ['setuptools_scm>=1.15.0']
 _SETUP_REQUIRES = ['setuptools>=18.0', 'pytest-runner',

--- a/tests.py
+++ b/tests.py
@@ -885,3 +885,61 @@ def test_new_style_metaclasses():
     class Triangle(Polygon, sides=3):
         def rotate(self):
             pass
+
+
+def test_descriptors_signature_getter():
+    class FooInterface(Interface):
+        @property
+        def someprop(self) -> str:
+            pass
+
+    with pytest.raises(NotImplementedError):
+        @implements(FooInterface)
+        class FooImplementationFail():
+            @property
+            def someprop(self) -> int:
+                pass
+
+
+def test_descriptors_signature_setter():
+    class FooInterface(Interface):
+        @property
+        def someprop(self):
+            pass
+
+        @someprop.setter
+        def someprop(self, value: str) -> str:
+            pass
+
+    with pytest.raises(NotImplementedError):
+        @implements(FooInterface)
+        class FooImplementationFail():
+            @property
+            def someprop(self):
+                pass
+
+            @someprop.setter
+            def someprop(self, value: int) -> float:
+                pass
+
+
+def test_descriptors_signature_deleter():
+    class FooInterface(Interface):
+        @property
+        def someprop(self):
+            pass
+
+        @someprop.deleter
+        def someprop(self) -> str:
+            pass
+
+    with pytest.raises(NotImplementedError):
+        @implements(FooInterface)
+        class FooImplementationFail():
+            @property
+            def someprop(self):
+                pass
+
+            @someprop.deleter
+            def someprop(self) -> int:
+                pass

--- a/tests.py
+++ b/tests.py
@@ -895,7 +895,7 @@ def test_descriptors_signature_getter():
 
     with pytest.raises(NotImplementedError):
         @implements(FooInterface)
-        class FooImplementationFail():
+        class FooImplementationFail:
             @property
             def someprop(self) -> int:
                 pass
@@ -913,7 +913,7 @@ def test_descriptors_signature_setter():
 
     with pytest.raises(NotImplementedError):
         @implements(FooInterface)
-        class FooImplementationFail():
+        class FooImplementationFail:
             @property
             def someprop(self):
                 pass
@@ -935,7 +935,7 @@ def test_descriptors_signature_deleter():
 
     with pytest.raises(NotImplementedError):
         @implements(FooInterface)
-        class FooImplementationFail():
+        class FooImplementationFail:
             @property
             def someprop(self):
                 pass

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@
 import sys
 import pytest
 
-from implements import Interface, implements
+from implements import Interface, implements, get_mro
 
 
 py36 = pytest.mark.skipif(sys.version_info < (3, 6), reason='requires py3.6')
@@ -942,4 +942,42 @@ def test_descriptors_signature_deleter():
 
             @someprop.deleter
             def someprop(self) -> int:
+                pass
+
+
+def test_get_mro():
+    class RegularClass:
+        pass
+
+    mro = get_mro(RegularClass)
+    assert object not in mro
+
+    expected = RegularClass.mro()[:-1]
+    assert mro == expected
+
+
+def test_class_hierarchy_overlap_of_common_class():
+    class CommonClass:
+        pass
+
+    class FooInterface(CommonClass):
+        def abc(self) -> str:
+            pass
+
+    with pytest.raises(ValueError):
+        @implements(FooInterface)
+        class FooImplemenation(CommonClass):
+            def abc(self) -> str:
+                pass
+
+
+def test_implementation_inheriting_from_interface():
+    class FooInterface:
+        def abc(self) -> str:
+            pass
+
+    with pytest.raises(ValueError):
+        @implements(FooInterface)
+        class FooImplemenation(FooInterface):
+            def abc(self) -> str:
                 pass

--- a/tests.py
+++ b/tests.py
@@ -152,6 +152,28 @@ def test_deleters():
             pass
 
 
+def test_implementation_implements_more_descriptors():
+    class FooInterface(Interface):
+        @property
+        def foo(self):
+            pass
+
+    #   An implementation must implement all data descriptors defined in
+    #   the interface, however, the implementation could define more.
+    #
+    #   The case below must not generate errors because FooImplementationPass
+    #   defines a foo.setter which isn't defined by FooInterface
+    @implements(FooInterface)
+    class FooImplementationPass:
+        @property
+        def foo(self):
+            pass
+
+        @foo.setter
+        def foo(self, val):
+            pass
+
+
 def test_missing_method():
     class FooInterface(Interface):
         def foo(self):


### PR DESCRIPTION
This version has:

#25: Fix: Extra data-descriptors from the implementation won't raise errors
#24: Implementations are prevented from inheriting from interfaces
#22: Method signatures of data-descriptors are additionally verified
#21: Interface errors are collected and reported together
